### PR TITLE
Add Docker support with Dockerfiles and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.gitignore
+*.md
+.env
+frontend/node_modules
+frontend/.env
+frontend/build
+backend/__pycache__
+backend/*.pyc
+backend/.venv
+backend/chatbot.db
+backend/chroma_db

--- a/.gitignore
+++ b/.gitignore
@@ -353,7 +353,6 @@ backend/.junit/
 # ==============================================
 
 # Docker
-.dockerignore
 docker-compose.override.yml
 
 # Deployment

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements_sqlite.txt .
+RUN pip install --no-cache-dir -r requirements_sqlite.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main_sqlite:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./backend/.env
+    volumes:
+      - chatbot_db:/app/chatbot.db
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_API_URL: http://localhost:8000
+    ports:
+      - "3000:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  chatbot_db:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:18-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ARG REACT_APP_API_URL=http://localhost:8000
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
+
+RUN npm run build
+
+FROM nginx:alpine
+
+COPY --from=build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -53,7 +53,7 @@ interface LoginResponse {
   user: User;
 }
 
-const API_BASE_URL = 'http://localhost:8000'; // backend
+const API_BASE_URL = process.env.REACT_APP_API_URL ?? 'http://localhost:8000';
 
 /**
  * Gets the authorization headers with JWT token


### PR DESCRIPTION
- backend/Dockerfile: Python 3.10-slim, installs from requirements_sqlite.txt
- frontend/Dockerfile: multi-stage build (Node 18 build + nginx serve)
- frontend/nginx.conf: serve React SPA with try_files fallback
- docker-compose.yml: backend (8000) + frontend (3000) with healthcheck and named volume for SQLite persistence
- .dockerignore: exclude node_modules, .venv, db files, build artifacts
- frontend/src/api.ts: use REACT_APP_API_URL env var (falls back to localhost:8000) so Docker builds can target a custom backend URL