### PR TITLE
Add RAG feature with ChromaDB + OpenAI embeddings

### DIFF
--- a/backend/chat_service_sqlite.py
+++ b/backend/chat_service_sqlite.py
@@ -5,6 +5,13 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+BASE_SYSTEM_PROMPT = (
+    "You are a helpful assistant chatbot. "
+    "Write mathematical equations using LaTeX syntax with $ delimiters "
+    "(e.g., $E = mc^2$ for inline, $$F = ma$$ for block equations)."
+)
+
+
 class ChatService:
     def __init__(self):
         try:
@@ -15,25 +22,41 @@ class ChatService:
             logger.error(f"Error initializing Anthropic client: {e}")
             raise e
 
-    async def generate_response(self, messages: list) -> str:
+    async def generate_response(self, messages: list, user_id: int = None) -> str:
         try:
-            system_prompt = (
-                "You are a helpful assistant chatbot. "
-                "Write mathematical equations using LaTeX syntax with $ delimiters "
-                "(e.g., $E = mc^2$ for inline, $$F = ma$$ for block equations)."
-            )
+            system_text = BASE_SYSTEM_PROMPT
 
-            formatted_messages = []
-            for row in messages:
-                role, content = row[0], row[1]  # SQLite returns tuples
-                formatted_messages.append({"role": role, "content": content})
+            # Inject RAG context when user_id is provided and RAG is configured
+            if user_id is not None:
+                try:
+                    from rag_service import rag_service
+                    if rag_service.is_configured():
+                        last_user_msg = next(
+                            (m[1] for m in reversed(messages) if m[0] == "user"), ""
+                        )
+                        if last_user_msg:
+                            chunks = rag_service.query(user_id, last_user_msg)
+                            if chunks:
+                                context = "\n\n---\n\n".join(chunks)
+                                system_text = (
+                                    BASE_SYSTEM_PROMPT
+                                    + "\n\n## Relevant Document Context\n\n"
+                                    + context
+                                    + "\n\nUse the above context to answer the user's question when relevant."
+                                )
+                except Exception as e:
+                    logger.warning(f"RAG context retrieval failed, proceeding without: {e}")
+
+            formatted_messages = [
+                {"role": m[0], "content": m[1]} for m in messages
+            ]
 
             response = await self.client.messages.create(
                 model="claude-haiku-4-5",
                 max_tokens=1024,
                 system=[{
                     "type": "text",
-                    "text": system_prompt,
+                    "text": system_text,
                     "cache_control": {"type": "ephemeral"},
                 }],
                 messages=formatted_messages,
@@ -44,5 +67,6 @@ class ChatService:
         except Exception as e:
             logger.error(f"Error generating response: {e}")
             return "I'm sorry, I encountered an error while processing your request."
+
 
 chat_service = ChatService()

--- a/backend/config_sqlite.py
+++ b/backend/config_sqlite.py
@@ -5,6 +5,7 @@ load_dotenv()
 
 class Settings:
     anthropic_api_key: str = os.getenv("ANTHROPIC_API_KEY")
+    openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
     database_url: str = os.getenv("DATABASE_URL", "chatbot.db")
 
 # Create an instance of the Settings class to access configuration variables

--- a/backend/database_sqlite.py
+++ b/backend/database_sqlite.py
@@ -56,11 +56,26 @@ class DatabaseManager:
             )
             """
             
+            # Create documents table for RAG
+            create_documents_table = """
+            CREATE TABLE IF NOT EXISTS documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                filename TEXT NOT NULL,
+                file_type TEXT NOT NULL,
+                chunk_count INTEGER DEFAULT 0,
+                is_global INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id)
+            )
+            """
+
             cursor.execute(create_users_table)
             cursor.execute(create_conversations_table)
             cursor.execute(create_messages_table)
-            self.connection.commit()    # commits the current transaction to the database
-            logger.info("SQLite tables created successfully")   # write log to the Terminal
+            cursor.execute(create_documents_table)
+            self.connection.commit()
+            logger.info("SQLite tables created successfully")
             
         except Exception as e:
             logger.error(f"Error creating tables: {e}")
@@ -255,6 +270,59 @@ class DatabaseManager:
             logger.error(f"Error fetching user by ID: {e}")
             return None
             
+    # Document methods for RAG
+
+    def create_document(self, user_id: int, filename: str, file_type: str, chunk_count: int, is_global: bool):
+        try:
+            cursor = self.connection.cursor()
+            cursor.execute(
+                "INSERT INTO documents (user_id, filename, file_type, chunk_count, is_global) VALUES (?, ?, ?, ?, ?)",
+                (user_id, filename, file_type, chunk_count, 1 if is_global else 0),
+            )
+            self.connection.commit()
+            return cursor.lastrowid
+        except Exception as e:
+            logger.error(f"Error creating document: {e}")
+            return None
+
+    def get_documents(self, user_id: int):
+        try:
+            cursor = self.connection.cursor()
+            cursor.execute(
+                """SELECT id, user_id, filename, file_type, chunk_count, is_global, created_at
+                   FROM documents
+                   WHERE user_id = ? OR is_global = 1
+                   ORDER BY created_at DESC""",
+                (user_id,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+        except Exception as e:
+            logger.error(f"Error fetching documents: {e}")
+            return []
+
+    def get_document_by_id(self, doc_id: int):
+        try:
+            cursor = self.connection.cursor()
+            cursor.execute(
+                "SELECT id, user_id, filename, file_type, chunk_count, is_global FROM documents WHERE id = ?",
+                (doc_id,),
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+        except Exception as e:
+            logger.error(f"Error fetching document {doc_id}: {e}")
+            return None
+
+    def delete_document(self, doc_id: int):
+        try:
+            cursor = self.connection.cursor()
+            cursor.execute("DELETE FROM documents WHERE id = ?", (doc_id,))
+            self.connection.commit()
+            return cursor.rowcount > 0
+        except Exception as e:
+            logger.error(f"Error deleting document {doc_id}: {e}")
+            return False
+
     def close(self):
         if self.connection:
             self.connection.close()

--- a/backend/main_sqlite.py
+++ b/backend/main_sqlite.py
@@ -17,7 +17,7 @@ Key Features:
 """
 
 # FastAPI framework imports for web API functionality
-from fastapi import FastAPI, HTTPException, Depends
+from fastapi import FastAPI, HTTPException, Depends, UploadFile, File, Form
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
@@ -32,6 +32,9 @@ from chat_service_sqlite import chat_service
 
 # Import authentication service for user management
 from auth_service import auth_service
+
+# Import RAG service for document management
+from rag_service import rag_service, chunk_text, extract_pdf_text
 
 # Import logging for debugging and monitoring
 import logging
@@ -271,9 +274,9 @@ async def chat(request: ChatRequest, current_user: UserResponse = Depends(get_cu
         logger.info(f"Retrieving conversation history for context")
         history = db_manager.get_conversation_history(conversation_id)
         
-        # Generate AI response using chat service (integrates with OpenAI)
+        # Generate AI response — pass user_id so RAG context can be injected
         logger.info("Generating AI response")
-        ai_response = await chat_service.generate_response(history)
+        ai_response = await chat_service.generate_response(history, user_id=current_user.id)
         
         # Save AI response to database
         logger.info("Saving AI response to database")
@@ -381,6 +384,85 @@ async def delete_conversation(conversation_id: int):
     except Exception as e:
         logger.error(f"Error deleting conversation: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
+
+# DOCUMENT / RAG ENDPOINTS
+
+@app.post("/documents/upload")
+async def upload_document(
+    file: UploadFile = File(...),
+    is_global: bool = Form(False),
+    current_user: UserResponse = Depends(get_current_user),
+):
+    """Upload a PDF or TXT file, embed its contents, and store in ChromaDB."""
+    if not rag_service.is_configured():
+        raise HTTPException(status_code=503, detail="RAG is not configured (OPENAI_API_KEY missing)")
+
+    filename = file.filename or "unknown"
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext not in ("pdf", "txt"):
+        raise HTTPException(status_code=400, detail="Only PDF and TXT files are supported")
+
+    try:
+        content = await file.read()
+        if ext == "pdf":
+            text = extract_pdf_text(content)
+        else:
+            text = content.decode("utf-8", errors="ignore")
+
+        if not text.strip():
+            raise HTTPException(status_code=400, detail="Could not extract text from the file")
+
+        chunks = chunk_text(text)
+        doc_id = db_manager.create_document(
+            user_id=current_user.id,
+            filename=filename,
+            file_type=ext,
+            chunk_count=len(chunks),
+            is_global=is_global,
+        )
+        if not doc_id:
+            raise HTTPException(status_code=500, detail="Failed to save document metadata")
+
+        rag_service.add_document(current_user.id, doc_id, filename, chunks, is_global)
+
+        logger.info(f"User {current_user.id} uploaded '{filename}' ({len(chunks)} chunks, global={is_global})")
+        return {"id": doc_id, "filename": filename, "file_type": ext, "chunk_count": len(chunks), "is_global": is_global}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error uploading document: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.get("/documents")
+async def list_documents(current_user: UserResponse = Depends(get_current_user)):
+    """List all documents accessible to the current user (personal + global)."""
+    try:
+        return db_manager.get_documents(current_user.id)
+    except Exception as e:
+        logger.error(f"Error listing documents: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.delete("/documents/{doc_id}")
+async def delete_document(doc_id: int, current_user: UserResponse = Depends(get_current_user)):
+    """Delete a document and its embeddings. Users can only delete their own documents."""
+    doc = db_manager.get_document_by_id(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+    if doc["user_id"] != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorised to delete this document")
+
+    try:
+        rag_service.delete_document(current_user.id, doc_id, bool(doc["is_global"]))
+        db_manager.delete_document(doc_id)
+        logger.info(f"User {current_user.id} deleted document {doc_id}")
+        return {"message": "Document deleted", "doc_id": doc_id}
+    except Exception as e:
+        logger.error(f"Error deleting document {doc_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/rag_service.py
+++ b/backend/rag_service.py
@@ -1,0 +1,123 @@
+import re
+import io
+import logging
+import chromadb
+from chromadb.config import Settings as ChromaSettings
+from config_sqlite import settings
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = 800
+CHUNK_OVERLAP = 100
+
+
+def chunk_text(text: str) -> list:
+    """Split text into overlapping fixed-size chunks."""
+    text = re.sub(r'\s+', ' ', text).strip()
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + CHUNK_SIZE, len(text))
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        if end == len(text):
+            break
+        start += CHUNK_SIZE - CHUNK_OVERLAP
+    return chunks
+
+
+def extract_pdf_text(file_bytes: bytes) -> str:
+    """Extract plain text from PDF bytes."""
+    try:
+        from pypdf import PdfReader
+        reader = PdfReader(io.BytesIO(file_bytes))
+        pages = [page.extract_text() or "" for page in reader.pages]
+        return "\n".join(pages)
+    except Exception as e:
+        logger.error(f"PDF extraction error: {e}")
+        return ""
+
+
+class RagService:
+    def __init__(self):
+        self._openai_client = None
+        self.chroma_client = chromadb.PersistentClient(
+            path="./chroma_db",
+            settings=ChromaSettings(anonymized_telemetry=False),
+        )
+
+    def is_configured(self) -> bool:
+        return bool(settings.openai_api_key)
+
+    @property
+    def openai_client(self):
+        if self._openai_client is None:
+            if not settings.openai_api_key:
+                raise ValueError("OPENAI_API_KEY is not set — RAG requires it for embeddings")
+            from openai import OpenAI
+            self._openai_client = OpenAI(api_key=settings.openai_api_key)
+        return self._openai_client
+
+    def _collection_name(self, user_id: int, is_global: bool) -> str:
+        return "global_docs" if is_global else f"user_{user_id}"
+
+    def _get_collection(self, name: str):
+        return self.chroma_client.get_or_create_collection(
+            name=name,
+            metadata={"hnsw:space": "cosine"},
+        )
+
+    def _embed(self, texts: list) -> list:
+        response = self.openai_client.embeddings.create(
+            model="text-embedding-3-small",
+            input=texts,
+        )
+        return [d.embedding for d in response.data]
+
+    def add_document(self, user_id: int, doc_id: int, filename: str, chunks: list, is_global: bool) -> None:
+        if not chunks:
+            return
+        embeddings = self._embed(chunks)
+        collection = self._get_collection(self._collection_name(user_id, is_global))
+        collection.add(
+            ids=[f"doc_{doc_id}_chunk_{i}" for i in range(len(chunks))],
+            embeddings=embeddings,
+            documents=chunks,
+            metadatas=[{"doc_id": doc_id, "user_id": user_id, "filename": filename} for _ in chunks],
+        )
+        logger.info(f"Added {len(chunks)} chunks for doc {doc_id} to ChromaDB")
+
+    def query(self, user_id: int, query_text: str, n_results: int = 3) -> list:
+        """Retrieve top-k relevant chunks from user + global collections."""
+        query_embedding = self._embed([query_text])[0]
+        results = []
+
+        for name in [f"user_{user_id}", "global_docs"]:
+            try:
+                col = self._get_collection(name)
+                count = col.count()
+                if count == 0:
+                    continue
+                res = col.query(
+                    query_embeddings=[query_embedding],
+                    n_results=min(n_results, count),
+                )
+                results.extend(res["documents"][0])
+            except Exception as e:
+                logger.warning(f"RAG query error on collection '{name}': {e}")
+
+        return results
+
+    def delete_document(self, user_id: int, doc_id: int, is_global: bool) -> None:
+        name = self._collection_name(user_id, is_global)
+        try:
+            col = self.chroma_client.get_collection(name)
+            col.delete(where={"doc_id": doc_id})
+            logger.info(f"Deleted doc {doc_id} chunks from collection '{name}'")
+        except Exception as e:
+            logger.warning(f"Could not delete doc {doc_id} from ChromaDB: {e}")
+
+
+rag_service = RagService()

--- a/backend/requirements_sqlite.txt
+++ b/backend/requirements_sqlite.txt
@@ -1,6 +1,9 @@
 fastapi==0.104.1
 uvicorn==0.24.0
 anthropic>=0.40.0
+openai>=1.50.0
+chromadb>=0.5.0
+pypdf>=3.0.0
 python-dotenv==1.0.0
 pydantic==2.9.2
 python-multipart==0.0.6

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -26,7 +26,7 @@
  * All methods return Promises and throw errors on network or server failure.
  */
 
-import { ChatRequest, ChatResponse, Message, ConversationSummary, FullConversation } from './types';
+import { ChatRequest, ChatResponse, Message, ConversationSummary, FullConversation, Document } from './types';
 
 // Authentication types
 interface User {
@@ -264,11 +264,57 @@ export const api = {
         ...getAuthHeaders(),
       },
     });
-    
+
     if (!response.ok) {
       throw new Error('Failed to delete conversation');
     }
 
     return response.json();
+  },
+
+  // Document / RAG endpoints
+
+  async uploadDocument(file: File, isGlobal: boolean): Promise<Document> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('is_global', String(isGlobal));
+
+    const response = await fetch(`${API_BASE_URL}/documents/upload`, {
+      method: 'POST',
+      headers: { ...getAuthHeaders() },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(err.detail || 'Failed to upload document');
+    }
+
+    return response.json();
+  },
+
+  async getDocuments(): Promise<Document[]> {
+    const response = await fetch(`${API_BASE_URL}/documents`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch documents');
+    }
+
+    return response.json();
+  },
+
+  async deleteDocument(docId: number): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/documents/${docId}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    });
+
+    if (!response.ok) {
+      const err = await response.json();
+      throw new Error(err.detail || 'Failed to delete document');
+    }
   },
 };

--- a/frontend/src/components/ChatBot.tsx
+++ b/frontend/src/components/ChatBot.tsx
@@ -5,6 +5,7 @@ import MessageBubble from './MessageBubble';
 import MessageInput from './MessageInput';
 import TypingIndicator from './TypingIndicator';
 import AllConversations from './AllConversations';
+import DocumentPanel from './DocumentPanel';
 // Import TypeScript types for type safety
 import { Message, FullConversation } from '../types';
 // Import API functions to communicate with the backend
@@ -284,9 +285,12 @@ const ChatBot: React.FC<ChatBotProps> = ({ currentUser, onLogout }) => {
             onSelectConversation={handleSelectConversation}
             onDeleteConversation={handleDeleteConversation}
             currentConversationId={conversationId || undefined}
-            refreshTrigger={refreshTrigger} // Triggers re-fetch when incremented
+            refreshTrigger={refreshTrigger}
           />
         </div>
+
+        {/* Document upload panel for RAG */}
+        <DocumentPanel />
       </div>
 
       {/* RESIZE HANDLE */}

--- a/frontend/src/components/DocumentPanel.tsx
+++ b/frontend/src/components/DocumentPanel.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Document } from '../types';
+import { api } from '../api';
+import '../styles/DocumentPanel.css';
+
+const DocumentPanel: React.FC = () => {
+  const [documents, setDocuments] = useState<Document[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isGlobal, setIsGlobal] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isExpanded) loadDocuments();
+  }, [isExpanded]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const loadDocuments = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const docs = await api.getDocuments();
+      setDocuments(docs);
+    } catch {
+      setError('Failed to load documents');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    setError(null);
+    try {
+      const doc = await api.uploadDocument(file, isGlobal);
+      setDocuments(prev => [doc, ...prev]);
+    } catch (err: any) {
+      setError(err.message || 'Upload failed');
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleDelete = async (docId: number) => {
+    try {
+      await api.deleteDocument(docId);
+      setDocuments(prev => prev.filter(d => d.id !== docId));
+    } catch (err: any) {
+      setError(err.message || 'Delete failed');
+    }
+  };
+
+  return (
+    <div className="document-panel">
+      <button
+        className="document-panel-toggle"
+        onClick={() => setIsExpanded(prev => !prev)}
+      >
+        <span>📄 Documents</span>
+        <span className={`toggle-arrow ${isExpanded ? 'open' : ''}`}>▾</span>
+      </button>
+
+      {isExpanded && (
+        <div className="document-panel-body">
+          {/* Upload controls */}
+          <div className="doc-upload-row">
+            <label className="scope-toggle">
+              <input
+                type="checkbox"
+                checked={isGlobal}
+                onChange={e => setIsGlobal(e.target.checked)}
+              />
+              <span>Global</span>
+            </label>
+            <button
+              className="doc-upload-btn"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+              title="Upload PDF or TXT"
+            >
+              {isUploading ? '⏳' : '+ Upload'}
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".pdf,.txt"
+              style={{ display: 'none' }}
+              onChange={handleFileChange}
+            />
+          </div>
+
+          {error && <div className="doc-error">{error}</div>}
+
+          {isLoading ? (
+            <div className="doc-loading">Loading…</div>
+          ) : documents.length === 0 ? (
+            <div className="doc-empty">No documents yet</div>
+          ) : (
+            <ul className="doc-list">
+              {documents.map(doc => (
+                <li key={doc.id} className="doc-item">
+                  <div className="doc-info">
+                    <span className="doc-name" title={doc.filename}>
+                      {doc.filename.length > 24
+                        ? doc.filename.slice(0, 21) + '…'
+                        : doc.filename}
+                    </span>
+                    <span className="doc-meta">
+                      {doc.chunk_count} chunks
+                      {doc.is_global ? ' · 🌐' : ' · 🔒'}
+                    </span>
+                  </div>
+                  <button
+                    className="doc-delete-btn"
+                    onClick={() => handleDelete(doc.id)}
+                    title="Delete document"
+                  >
+                    🗑️
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DocumentPanel;

--- a/frontend/src/styles/DocumentPanel.css
+++ b/frontend/src/styles/DocumentPanel.css
@@ -1,0 +1,157 @@
+.document-panel {
+  border-top: 1px solid var(--border-color, #e2e8f0);
+  background: var(--sidebar-bg, #f8fafc);
+}
+
+.document-panel-toggle {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary, #1e293b);
+  transition: background 0.15s;
+}
+
+.document-panel-toggle:hover {
+  background: var(--hover-bg, #e2e8f0);
+}
+
+.toggle-arrow {
+  display: inline-block;
+  transition: transform 0.2s;
+  font-size: 0.75rem;
+}
+
+.toggle-arrow.open {
+  transform: rotate(180deg);
+}
+
+.document-panel-body {
+  padding: 0 12px 12px;
+}
+
+.doc-upload-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.scope-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  color: var(--text-secondary, #64748b);
+  cursor: pointer;
+  user-select: none;
+}
+
+.scope-toggle input {
+  cursor: pointer;
+  accent-color: #6366f1;
+}
+
+.doc-upload-btn {
+  margin-left: auto;
+  padding: 4px 10px;
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.doc-upload-btn:hover:not(:disabled) {
+  background: #4f46e5;
+}
+
+.doc-upload-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.doc-error {
+  font-size: 0.75rem;
+  color: #ef4444;
+  margin-bottom: 6px;
+  padding: 4px 8px;
+  background: #fef2f2;
+  border-radius: 4px;
+}
+
+.doc-loading,
+.doc-empty {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #94a3b8);
+  text-align: center;
+  padding: 8px 0;
+}
+
+.doc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.doc-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 6px;
+  padding: 6px 8px;
+  gap: 6px;
+}
+
+.doc-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.doc-name {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-primary, #1e293b);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.doc-meta {
+  font-size: 0.7rem;
+  color: var(--text-secondary, #94a3b8);
+}
+
+.doc-delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+  opacity: 0.6;
+  transition: opacity 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.doc-delete-btn:hover {
+  opacity: 1;
+  background: #fee2e2;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -80,6 +80,16 @@ export interface ConversationSummary {
  * Used when loading conversation history from the backend
  * Corresponds to the FullConversation Pydantic model in the backend
  */
+export interface Document {
+  id: number;
+  user_id: number;
+  filename: string;
+  file_type: string;
+  chunk_count: number;
+  is_global: boolean | number;
+  created_at: string;
+}
+
 export interface FullConversation {
   conversation: {
     id: number;                  // Conversation unique identifier


### PR DESCRIPTION
Backend:
- rag_service.py: ChromaDB PersistentClient, OpenAI text-embedding-3-small, chunk_text (800-char overlapping), extract_pdf_text (pypdf), per-user + global collections, lazy OpenAI init (graceful when key is absent)
- database_sqlite.py: documents table + CRUD (create/get/delete)
- main_sqlite.py: POST /documents/upload, GET /documents, DELETE /documents/{id}
- chat_service_sqlite.py: inject top-k RAG chunks into system prompt when OPENAI_API_KEY is set; falls back gracefully if not configured
- config_sqlite.py: expose openai_api_key setting
- requirements_sqlite.txt: add openai, chromadb, pypdf

Frontend:
- types.ts: Document interface
- api.ts: uploadDocument, getDocuments, deleteDocument methods
- DocumentPanel.tsx: collapsible sidebar panel with file upload (PDF/TXT), personal/global scope toggle, doc list with delete
- DocumentPanel.css: styles for the panel
- ChatBot.tsx: render DocumentPanel at bottom of left sidebar